### PR TITLE
feat: add capacitor and inductor models

### DIFF
--- a/src/engine/components/capacitor.ts
+++ b/src/engine/components/capacitor.ts
@@ -1,0 +1,144 @@
+import type { Capacitor, Terminal } from '@/types/component';
+import { WebSpiceError } from '@/types/circuit';
+
+/**
+ * Capacitor component implementation.
+ *
+ * Capacitance must be positive, finite, and within a practical range.
+ * DC analysis treats capacitors as open circuits, so this model only stores
+ * validated component data for parsers and future analysis modes.
+ */
+export class CapacitorImpl implements Capacitor {
+  /** Minimum allowed capacitance: 1 pF */
+  private static readonly MIN_CAPACITANCE = 1e-12;
+  /** Maximum allowed capacitance: 1 F */
+  private static readonly MAX_CAPACITANCE = 1.0;
+  private readonly _id!: string;
+  private readonly _type = 'capacitor' as const;
+  private readonly _name!: string;
+  private readonly _capacitance!: number;
+  private readonly _initialVoltage?: number;
+  private readonly _terminals!: readonly [Terminal, Terminal];
+
+  /**
+   * Creates a new Capacitor instance.
+   *
+   * @param data - Capacitor data object
+   * @throws {WebSpiceError} If parameters are invalid
+   */
+  constructor(data: Capacitor) {
+    if (!data.id || data.id.trim().length === 0) {
+      throw new WebSpiceError(
+        'INVALID_COMPONENT',
+        'Component ID cannot be empty',
+        { componentId: data.id }
+      );
+    }
+
+    const [term1, term2] = data.terminals;
+
+    if (!term1.nodeId || term1.nodeId.trim().length === 0) {
+      throw new WebSpiceError('INVALID_COMPONENT', 'Node ID cannot be empty', {
+        componentId: data.id,
+      });
+    }
+
+    if (!term2.nodeId || term2.nodeId.trim().length === 0) {
+      throw new WebSpiceError('INVALID_COMPONENT', 'Node ID cannot be empty', {
+        componentId: data.id,
+      });
+    }
+
+    if (term1.nodeId.trim() === term2.nodeId.trim()) {
+      throw new WebSpiceError(
+        'INVALID_COMPONENT',
+        'Terminals cannot be connected to the same node',
+        { componentId: data.id }
+      );
+    }
+
+    if (!Number.isFinite(data.capacitance)) {
+      throw new WebSpiceError(
+        'INVALID_PARAMETER',
+        'Capacitance must be a finite number',
+        { componentId: data.id }
+      );
+    }
+
+    if (data.capacitance <= 0) {
+      throw new WebSpiceError(
+        'INVALID_PARAMETER',
+        'Capacitance must be greater than 0',
+        { componentId: data.id }
+      );
+    }
+
+    if (
+      data.capacitance < CapacitorImpl.MIN_CAPACITANCE ||
+      data.capacitance > CapacitorImpl.MAX_CAPACITANCE
+    ) {
+      throw new WebSpiceError(
+        'INVALID_PARAMETER',
+        'Capacitance must be between 1e-12 and 1 Farads',
+        { componentId: data.id }
+      );
+    }
+
+    if (
+      data.initialVoltage !== undefined &&
+      !Number.isFinite(data.initialVoltage)
+    ) {
+      throw new WebSpiceError(
+        'INVALID_PARAMETER',
+        'Initial voltage must be a finite number',
+        { componentId: data.id }
+      );
+    }
+
+    this._id = data.id.trim();
+    this._name = (data.name && data.name.trim()) || this._id;
+    this._capacitance = data.capacitance;
+    this._initialVoltage = data.initialVoltage;
+    this._terminals = [
+      { ...term1, nodeId: term1.nodeId.trim() },
+      { ...term2, nodeId: term2.nodeId.trim() },
+    ];
+  }
+
+  get id(): string {
+    return this._id;
+  }
+
+  get type(): 'capacitor' {
+    return this._type;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  get capacitance(): number {
+    return this._capacitance;
+  }
+
+  get initialVoltage(): number | undefined {
+    return this._initialVoltage;
+  }
+
+  get terminals(): [Terminal, Terminal] {
+    return [{ ...this._terminals[0] }, { ...this._terminals[1] }];
+  }
+
+  toJSON(): Capacitor {
+    return {
+      id: this._id,
+      type: this._type,
+      name: this._name,
+      capacitance: this._capacitance,
+      ...(this._initialVoltage !== undefined
+        ? { initialVoltage: this._initialVoltage }
+        : {}),
+      terminals: this.terminals,
+    };
+  }
+}

--- a/src/engine/components/inductor.ts
+++ b/src/engine/components/inductor.ts
@@ -1,0 +1,144 @@
+import type { Inductor, Terminal } from '@/types/component';
+import { WebSpiceError } from '@/types/circuit';
+
+/**
+ * Inductor component implementation.
+ *
+ * Inductance must be positive, finite, and within a practical range.
+ * DC validation currently rejects inductors before MNA assembly, so this model
+ * only stores validated component data for parsers and future analysis modes.
+ */
+export class InductorImpl implements Inductor {
+  /** Minimum allowed inductance: 1 nH */
+  private static readonly MIN_INDUCTANCE = 1e-9;
+  /** Maximum allowed inductance: 1 kH */
+  private static readonly MAX_INDUCTANCE = 1e3;
+  private readonly _id!: string;
+  private readonly _type = 'inductor' as const;
+  private readonly _name!: string;
+  private readonly _inductance!: number;
+  private readonly _initialCurrent?: number;
+  private readonly _terminals!: readonly [Terminal, Terminal];
+
+  /**
+   * Creates a new Inductor instance.
+   *
+   * @param data - Inductor data object
+   * @throws {WebSpiceError} If parameters are invalid
+   */
+  constructor(data: Inductor) {
+    if (!data.id || data.id.trim().length === 0) {
+      throw new WebSpiceError(
+        'INVALID_COMPONENT',
+        'Component ID cannot be empty',
+        { componentId: data.id }
+      );
+    }
+
+    const [term1, term2] = data.terminals;
+
+    if (!term1.nodeId || term1.nodeId.trim().length === 0) {
+      throw new WebSpiceError('INVALID_COMPONENT', 'Node ID cannot be empty', {
+        componentId: data.id,
+      });
+    }
+
+    if (!term2.nodeId || term2.nodeId.trim().length === 0) {
+      throw new WebSpiceError('INVALID_COMPONENT', 'Node ID cannot be empty', {
+        componentId: data.id,
+      });
+    }
+
+    if (term1.nodeId.trim() === term2.nodeId.trim()) {
+      throw new WebSpiceError(
+        'INVALID_COMPONENT',
+        'Terminals cannot be connected to the same node',
+        { componentId: data.id }
+      );
+    }
+
+    if (!Number.isFinite(data.inductance)) {
+      throw new WebSpiceError(
+        'INVALID_PARAMETER',
+        'Inductance must be a finite number',
+        { componentId: data.id }
+      );
+    }
+
+    if (data.inductance <= 0) {
+      throw new WebSpiceError(
+        'INVALID_PARAMETER',
+        'Inductance must be greater than 0',
+        { componentId: data.id }
+      );
+    }
+
+    if (
+      data.inductance < InductorImpl.MIN_INDUCTANCE ||
+      data.inductance > InductorImpl.MAX_INDUCTANCE
+    ) {
+      throw new WebSpiceError(
+        'INVALID_PARAMETER',
+        'Inductance must be between 1e-9 and 1e3 Henrys',
+        { componentId: data.id }
+      );
+    }
+
+    if (
+      data.initialCurrent !== undefined &&
+      !Number.isFinite(data.initialCurrent)
+    ) {
+      throw new WebSpiceError(
+        'INVALID_PARAMETER',
+        'Initial current must be a finite number',
+        { componentId: data.id }
+      );
+    }
+
+    this._id = data.id.trim();
+    this._name = (data.name && data.name.trim()) || this._id;
+    this._inductance = data.inductance;
+    this._initialCurrent = data.initialCurrent;
+    this._terminals = [
+      { ...term1, nodeId: term1.nodeId.trim() },
+      { ...term2, nodeId: term2.nodeId.trim() },
+    ];
+  }
+
+  get id(): string {
+    return this._id;
+  }
+
+  get type(): 'inductor' {
+    return this._type;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  get inductance(): number {
+    return this._inductance;
+  }
+
+  get initialCurrent(): number | undefined {
+    return this._initialCurrent;
+  }
+
+  get terminals(): [Terminal, Terminal] {
+    return [{ ...this._terminals[0] }, { ...this._terminals[1] }];
+  }
+
+  toJSON(): Inductor {
+    return {
+      id: this._id,
+      type: this._type,
+      name: this._name,
+      inductance: this._inductance,
+      ...(this._initialCurrent !== undefined
+        ? { initialCurrent: this._initialCurrent }
+        : {}),
+      terminals: this.terminals,
+    };
+  }
+}

--- a/src/engine/parser/circuitParser.ts
+++ b/src/engine/parser/circuitParser.ts
@@ -3,6 +3,8 @@ import type { Component } from '@/types/component';
 import { WebSpiceError } from '@/types/circuit';
 import { CircuitImpl } from '@/engine/circuit';
 import { ResistorImpl } from '@/engine/components/resistor';
+import { CapacitorImpl } from '@/engine/components/capacitor';
+import { InductorImpl } from '@/engine/components/inductor';
 import { DCVoltageSourceImpl } from '@/engine/components/dcVoltageSource';
 import { DCCurrentSourceImpl } from '@/engine/components/dcCurrentSource';
 import { parseSIValue } from '@/engine/parser/siPrefix';
@@ -59,6 +61,10 @@ function parseComponent(json: ComponentJSON): Component {
   switch (json.type) {
     case 'resistor':
       return parseResistor(json);
+    case 'capacitor':
+      return parseCapacitor(json);
+    case 'inductor':
+      return parseInductor(json);
     case 'voltage_source':
       return parseVoltageSource(json);
     case 'current_source':
@@ -83,6 +89,44 @@ function parseResistor(json: ComponentJSON): Component {
     type: 'resistor',
     name: json.name,
     resistance: parseSIValue(json.parameters.resistance),
+    terminals: [
+      { name: 'terminal1', nodeId: json.nodes[0] },
+      { name: 'terminal2', nodeId: json.nodes[1] },
+    ],
+  });
+}
+
+function parseCapacitor(json: ComponentJSON): Component {
+  assertNodeCount(json, 2);
+  assertRequiredParameter(json, 'capacitance');
+
+  return new CapacitorImpl({
+    id: json.id,
+    type: 'capacitor',
+    name: json.name,
+    capacitance: parseSIValue(json.parameters.capacitance),
+    ...(json.parameters.initialVoltage !== undefined
+      ? { initialVoltage: parseSIValue(json.parameters.initialVoltage) }
+      : {}),
+    terminals: [
+      { name: 'pos', nodeId: json.nodes[0] },
+      { name: 'neg', nodeId: json.nodes[1] },
+    ],
+  });
+}
+
+function parseInductor(json: ComponentJSON): Component {
+  assertNodeCount(json, 2);
+  assertRequiredParameter(json, 'inductance');
+
+  return new InductorImpl({
+    id: json.id,
+    type: 'inductor',
+    name: json.name,
+    inductance: parseSIValue(json.parameters.inductance),
+    ...(json.parameters.initialCurrent !== undefined
+      ? { initialCurrent: parseSIValue(json.parameters.initialCurrent) }
+      : {}),
     terminals: [
       { name: 'terminal1', nodeId: json.nodes[0] },
       { name: 'terminal2', nodeId: json.nodes[1] },

--- a/tests/engine/components/capacitor.test.ts
+++ b/tests/engine/components/capacitor.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest';
+import { CapacitorImpl } from '@/engine/components/capacitor';
+import type { Capacitor } from '@/types/component';
+
+/**
+ * Helper function to create capacitor test data with optional overrides
+ */
+function makeCapacitorData(overrides?: Partial<Capacitor>): Capacitor {
+  return {
+    id: 'C1',
+    type: 'capacitor',
+    name: 'C1',
+    capacitance: 1e-6,
+    terminals: [
+      { name: 'pos', nodeId: 'n1' },
+      { name: 'neg', nodeId: 'n2' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('Capacitor', () => {
+  describe('constructor (data object)', () => {
+    it('should create a capacitor with valid data object', () => {
+      const capacitor = new CapacitorImpl(makeCapacitorData());
+
+      expect(capacitor.id).toBe('C1');
+      expect(capacitor.type).toBe('capacitor');
+      expect(capacitor.name).toBe('C1');
+      expect(capacitor.capacitance).toBe(1e-6);
+      expect(capacitor.initialVoltage).toBeUndefined();
+      expect(capacitor.terminals).toHaveLength(2);
+      expect(capacitor.terminals[0]).toEqual({
+        name: 'pos',
+        nodeId: 'n1',
+      });
+      expect(capacitor.terminals[1]).toEqual({
+        name: 'neg',
+        nodeId: 'n2',
+      });
+    });
+
+    it('should use id as name when name is not provided', () => {
+      const capacitor = new CapacitorImpl(makeCapacitorData({ name: '' }));
+
+      expect(capacitor.name).toBe('C1');
+    });
+
+    it('should throw error for zero capacitance', () => {
+      expect(
+        () => new CapacitorImpl(makeCapacitorData({ capacitance: 0 }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should throw error for negative capacitance', () => {
+      expect(
+        () => new CapacitorImpl(makeCapacitorData({ capacitance: -1e-6 }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should throw error for invalid capacitance (NaN)', () => {
+      expect(
+        () => new CapacitorImpl(makeCapacitorData({ capacitance: NaN }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should throw error for invalid capacitance (Infinity)', () => {
+      expect(
+        () => new CapacitorImpl(makeCapacitorData({ capacitance: Infinity }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should throw error for capacitance below minimum (< 1 pF)', () => {
+      expect(
+        () => new CapacitorImpl(makeCapacitorData({ capacitance: 1e-13 }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should throw error for capacitance above maximum (> 1 F)', () => {
+      expect(
+        () => new CapacitorImpl(makeCapacitorData({ capacitance: 2 }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should throw error for empty component ID', () => {
+      expect(
+        () => new CapacitorImpl(makeCapacitorData({ id: '' }))
+      ).toThrowWebSpiceError('INVALID_COMPONENT');
+    });
+
+    it('should throw error for empty node IDs', () => {
+      expect(
+        () =>
+          new CapacitorImpl(
+            makeCapacitorData({
+              terminals: [
+                { name: 'pos', nodeId: '' },
+                { name: 'neg', nodeId: 'n2' },
+              ],
+            })
+          )
+      ).toThrowWebSpiceError('INVALID_COMPONENT');
+
+      expect(
+        () =>
+          new CapacitorImpl(
+            makeCapacitorData({
+              terminals: [
+                { name: 'pos', nodeId: 'n1' },
+                { name: 'neg', nodeId: '' },
+              ],
+            })
+          )
+      ).toThrowWebSpiceError('INVALID_COMPONENT');
+    });
+
+    it('should throw error for identical node IDs', () => {
+      expect(
+        () =>
+          new CapacitorImpl(
+            makeCapacitorData({
+              terminals: [
+                { name: 'pos', nodeId: 'n1' },
+                { name: 'neg', nodeId: 'n1' },
+              ],
+            })
+          )
+      ).toThrowWebSpiceError('INVALID_COMPONENT');
+    });
+
+    it('should throw error for invalid initial voltage (NaN)', () => {
+      expect(
+        () => new CapacitorImpl(makeCapacitorData({ initialVoltage: NaN }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should allow omitted initial voltage', () => {
+      const capacitor = new CapacitorImpl(makeCapacitorData());
+
+      expect(capacitor.initialVoltage).toBeUndefined();
+    });
+
+    it('should allow negative initial voltage', () => {
+      const capacitor = new CapacitorImpl(
+        makeCapacitorData({ initialVoltage: -5 })
+      );
+
+      expect(capacitor.initialVoltage).toBe(-5);
+    });
+  });
+
+  describe('boundary values', () => {
+    it('should accept minimum capacitance (1 pF)', () => {
+      const capacitor = new CapacitorImpl(
+        makeCapacitorData({ capacitance: 1e-12 })
+      );
+
+      expect(capacitor.capacitance).toBe(1e-12);
+    });
+
+    it('should accept maximum capacitance (1 F)', () => {
+      const capacitor = new CapacitorImpl(
+        makeCapacitorData({ capacitance: 1 })
+      );
+
+      expect(capacitor.capacitance).toBe(1);
+    });
+  });
+
+  describe('type compliance', () => {
+    it('should match Capacitor interface', () => {
+      const capacitor = new CapacitorImpl(makeCapacitorData());
+      const typed: Capacitor = capacitor;
+
+      expect(typed.id).toBe('C1');
+      expect(typed.type).toBe('capacitor');
+      expect(typed.capacitance).toBe(1e-6);
+      expect(typed.terminals).toHaveLength(2);
+    });
+
+    it('should be serializable to plain object', () => {
+      const capacitor = new CapacitorImpl(
+        makeCapacitorData({ initialVoltage: -5 })
+      );
+      const json = JSON.stringify(capacitor);
+      const parsed = JSON.parse(json);
+
+      expect(parsed).toEqual({
+        id: 'C1',
+        type: 'capacitor',
+        name: 'C1',
+        capacitance: 1e-6,
+        initialVoltage: -5,
+        terminals: [
+          { name: 'pos', nodeId: 'n1' },
+          { name: 'neg', nodeId: 'n2' },
+        ],
+      });
+    });
+  });
+
+  describe('immutability', () => {
+    it('should not allow modification of terminals array', () => {
+      const capacitor = new CapacitorImpl(makeCapacitorData());
+      const originalTerminals = capacitor.terminals;
+
+      originalTerminals[0] = { name: 'neg', nodeId: 'n99' };
+
+      expect(capacitor.terminals[0].nodeId).toBe('n1');
+    });
+  });
+});

--- a/tests/engine/components/inductor.test.ts
+++ b/tests/engine/components/inductor.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import { InductorImpl } from '@/engine/components/inductor';
+import type { Inductor } from '@/types/component';
+
+/**
+ * Helper function to create inductor test data with optional overrides
+ */
+function makeInductorData(overrides?: Partial<Inductor>): Inductor {
+  return {
+    id: 'L1',
+    type: 'inductor',
+    name: 'L1',
+    inductance: 1e-3,
+    terminals: [
+      { name: 'terminal1', nodeId: 'n1' },
+      { name: 'terminal2', nodeId: 'n2' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('Inductor', () => {
+  describe('constructor (data object)', () => {
+    it('should create an inductor with valid data object', () => {
+      const inductor = new InductorImpl(makeInductorData());
+
+      expect(inductor.id).toBe('L1');
+      expect(inductor.type).toBe('inductor');
+      expect(inductor.name).toBe('L1');
+      expect(inductor.inductance).toBe(1e-3);
+      expect(inductor.initialCurrent).toBeUndefined();
+      expect(inductor.terminals).toHaveLength(2);
+      expect(inductor.terminals[0]).toEqual({
+        name: 'terminal1',
+        nodeId: 'n1',
+      });
+      expect(inductor.terminals[1]).toEqual({
+        name: 'terminal2',
+        nodeId: 'n2',
+      });
+    });
+
+    it('should use id as name when name is not provided', () => {
+      const inductor = new InductorImpl(makeInductorData({ name: '' }));
+
+      expect(inductor.name).toBe('L1');
+    });
+
+    it('should throw error for zero inductance', () => {
+      expect(
+        () => new InductorImpl(makeInductorData({ inductance: 0 }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should throw error for negative inductance', () => {
+      expect(
+        () => new InductorImpl(makeInductorData({ inductance: -1e-3 }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should throw error for invalid inductance (NaN)', () => {
+      expect(
+        () => new InductorImpl(makeInductorData({ inductance: NaN }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should throw error for invalid inductance (Infinity)', () => {
+      expect(
+        () => new InductorImpl(makeInductorData({ inductance: Infinity }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should throw error for inductance below minimum (< 1 nH)', () => {
+      expect(
+        () => new InductorImpl(makeInductorData({ inductance: 1e-10 }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should throw error for inductance above maximum (> 1 kH)', () => {
+      expect(
+        () => new InductorImpl(makeInductorData({ inductance: 1e4 }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should throw error for empty component ID', () => {
+      expect(
+        () => new InductorImpl(makeInductorData({ id: '' }))
+      ).toThrowWebSpiceError('INVALID_COMPONENT');
+    });
+
+    it('should throw error for empty node IDs', () => {
+      expect(
+        () =>
+          new InductorImpl(
+            makeInductorData({
+              terminals: [
+                { name: 'terminal1', nodeId: '' },
+                { name: 'terminal2', nodeId: 'n2' },
+              ],
+            })
+          )
+      ).toThrowWebSpiceError('INVALID_COMPONENT');
+
+      expect(
+        () =>
+          new InductorImpl(
+            makeInductorData({
+              terminals: [
+                { name: 'terminal1', nodeId: 'n1' },
+                { name: 'terminal2', nodeId: '' },
+              ],
+            })
+          )
+      ).toThrowWebSpiceError('INVALID_COMPONENT');
+    });
+
+    it('should throw error for identical node IDs', () => {
+      expect(
+        () =>
+          new InductorImpl(
+            makeInductorData({
+              terminals: [
+                { name: 'terminal1', nodeId: 'n1' },
+                { name: 'terminal2', nodeId: 'n1' },
+              ],
+            })
+          )
+      ).toThrowWebSpiceError('INVALID_COMPONENT');
+    });
+
+    it('should throw error for invalid initial current (NaN)', () => {
+      expect(
+        () => new InductorImpl(makeInductorData({ initialCurrent: NaN }))
+      ).toThrowWebSpiceError('INVALID_PARAMETER');
+    });
+
+    it('should allow omitted initial current', () => {
+      const inductor = new InductorImpl(makeInductorData());
+
+      expect(inductor.initialCurrent).toBeUndefined();
+    });
+
+    it('should allow negative initial current', () => {
+      const inductor = new InductorImpl(
+        makeInductorData({ initialCurrent: -0.5 })
+      );
+
+      expect(inductor.initialCurrent).toBe(-0.5);
+    });
+  });
+
+  describe('boundary values', () => {
+    it('should accept minimum inductance (1 nH)', () => {
+      const inductor = new InductorImpl(makeInductorData({ inductance: 1e-9 }));
+
+      expect(inductor.inductance).toBe(1e-9);
+    });
+
+    it('should accept maximum inductance (1 kH)', () => {
+      const inductor = new InductorImpl(makeInductorData({ inductance: 1e3 }));
+
+      expect(inductor.inductance).toBe(1e3);
+    });
+  });
+
+  describe('type compliance', () => {
+    it('should match Inductor interface', () => {
+      const inductor = new InductorImpl(makeInductorData());
+      const typed: Inductor = inductor;
+
+      expect(typed.id).toBe('L1');
+      expect(typed.type).toBe('inductor');
+      expect(typed.inductance).toBe(1e-3);
+      expect(typed.terminals).toHaveLength(2);
+    });
+
+    it('should be serializable to plain object', () => {
+      const inductor = new InductorImpl(
+        makeInductorData({ initialCurrent: -0.5 })
+      );
+      const json = JSON.stringify(inductor);
+      const parsed = JSON.parse(json);
+
+      expect(parsed).toEqual({
+        id: 'L1',
+        type: 'inductor',
+        name: 'L1',
+        inductance: 1e-3,
+        initialCurrent: -0.5,
+        terminals: [
+          { name: 'terminal1', nodeId: 'n1' },
+          { name: 'terminal2', nodeId: 'n2' },
+        ],
+      });
+    });
+  });
+
+  describe('immutability', () => {
+    it('should not allow modification of terminals array', () => {
+      const inductor = new InductorImpl(makeInductorData());
+      const originalTerminals = inductor.terminals;
+
+      originalTerminals[0] = { name: 'terminal2', nodeId: 'n99' };
+
+      expect(inductor.terminals[0].nodeId).toBe('n1');
+    });
+  });
+});

--- a/tests/engine/integration/dcAnalysisPipeline.test.ts
+++ b/tests/engine/integration/dcAnalysisPipeline.test.ts
@@ -278,11 +278,11 @@ describe('DC Analysis Pipeline', () => {
         ground: '0',
         components: [
           {
-            id: 'C1',
-            type: 'capacitor',
-            name: 'C1',
+            id: 'D1',
+            type: 'diode',
+            name: 'D1',
             nodes: ['1', '0'],
-            parameters: { capacitance: 1e-6 },
+            parameters: { modelName: 'default' },
           },
         ],
       };

--- a/tests/engine/parser/circuitParser.test.ts
+++ b/tests/engine/parser/circuitParser.test.ts
@@ -203,6 +203,90 @@ describe('Circuit Parser', () => {
     });
   });
 
+  describe('component parsing - capacitor', () => {
+    it('should parse a capacitor with correct properties', () => {
+      const json = makeCircuitJSON({
+        components: [
+          {
+            id: 'C1',
+            type: 'capacitor',
+            name: 'Filter Capacitor',
+            nodes: ['1', '0'],
+            parameters: { capacitance: '1u', initialVoltage: -5 },
+          },
+          {
+            id: 'GND',
+            type: 'ground',
+            name: 'GND',
+            nodes: ['0'],
+            parameters: {},
+          },
+        ],
+      });
+
+      const circuit = parseCircuit(json);
+      const capacitor = circuit.components.find(c => c.id === 'C1');
+
+      expect(capacitor).toBeDefined();
+      expect(capacitor!.type).toBe('capacitor');
+      if (capacitor!.type === 'capacitor') {
+        expect(capacitor!.capacitance).toBeCloseTo(1e-6, 15);
+        expect(capacitor!.initialVoltage).toBe(-5);
+        expect(capacitor!.name).toBe('Filter Capacitor');
+        expect(capacitor!.terminals[0]).toEqual({
+          name: 'pos',
+          nodeId: '1',
+        });
+        expect(capacitor!.terminals[1]).toEqual({
+          name: 'neg',
+          nodeId: '0',
+        });
+      }
+    });
+  });
+
+  describe('component parsing - inductor', () => {
+    it('should parse an inductor with correct properties', () => {
+      const json = makeCircuitJSON({
+        components: [
+          {
+            id: 'L1',
+            type: 'inductor',
+            name: 'Choke',
+            nodes: ['1', '0'],
+            parameters: { inductance: '10m', initialCurrent: -0.5 },
+          },
+          {
+            id: 'GND',
+            type: 'ground',
+            name: 'GND',
+            nodes: ['0'],
+            parameters: {},
+          },
+        ],
+      });
+
+      const circuit = parseCircuit(json);
+      const inductor = circuit.components.find(c => c.id === 'L1');
+
+      expect(inductor).toBeDefined();
+      expect(inductor!.type).toBe('inductor');
+      if (inductor!.type === 'inductor') {
+        expect(inductor!.inductance).toBeCloseTo(0.01, 15);
+        expect(inductor!.initialCurrent).toBe(-0.5);
+        expect(inductor!.name).toBe('Choke');
+        expect(inductor!.terminals[0]).toEqual({
+          name: 'terminal1',
+          nodeId: '1',
+        });
+        expect(inductor!.terminals[1]).toEqual({
+          name: 'terminal2',
+          nodeId: '0',
+        });
+      }
+    });
+  });
+
   describe('component parsing - voltage source', () => {
     it('should parse a DC voltage source with explicit sourceType', () => {
       const json = makeCircuitJSON();
@@ -409,42 +493,6 @@ describe('Circuit Parser', () => {
   });
 
   describe('error: unsupported component types', () => {
-    it('should throw error for capacitor (not yet supported)', () => {
-      expect(() =>
-        parseCircuit(
-          makeCircuitJSON({
-            components: [
-              {
-                id: 'C1',
-                type: 'capacitor',
-                name: 'C1',
-                nodes: ['1', '0'],
-                parameters: { capacitance: 1e-6 },
-              },
-            ],
-          })
-        )
-      ).toThrowWebSpiceError('UNSUPPORTED_ANALYSIS');
-    });
-
-    it('should throw error for inductor (not yet supported)', () => {
-      expect(() =>
-        parseCircuit(
-          makeCircuitJSON({
-            components: [
-              {
-                id: 'L1',
-                type: 'inductor',
-                name: 'L1',
-                nodes: ['1', '0'],
-                parameters: { inductance: 1e-3 },
-              },
-            ],
-          })
-        )
-      ).toThrowWebSpiceError('UNSUPPORTED_ANALYSIS');
-    });
-
     it('should throw error for AC voltage source (not yet supported)', () => {
       expect(() =>
         parseCircuit(


### PR DESCRIPTION
## 📋 변경 사항 요약

CapacitorImpl과 InductorImpl을 추가하고, JSON circuit parser에서 `capacitor`/`inductor` 타입을 함께 파싱하도록 확장했습니다. 두 brief가 공유하는 `circuitParser.ts` 변경은 하나의 PR에 포함했으며, 기존 capacitor/inductor 미지원 기대 테스트를 새 동작에 맞게 갱신했습니다.

## 🔗 관련 Issue

- Closes #21
- Closes #22

## 🛠 변경 내용

### 추가된 기능

- `src/engine/components/capacitor.ts`: 1pF~1F 범위 검증, `initialVoltage` finite 검증, `pos`/`neg` 터미널, `toJSON()` 지원
- `src/engine/components/inductor.ts`: 1nH~1kH 범위 검증, `initialCurrent` finite 검증, `terminal1`/`terminal2` 터미널, `toJSON()` 지원
- `src/engine/parser/circuitParser.ts`: `capacitor`와 `inductor` import/case/parser 함수 추가
- `tests/engine/components/capacitor.test.ts`, `tests/engine/components/inductor.test.ts`: brief 지정 검증 케이스 추가

### 수정된 기능

- `tests/engine/parser/circuitParser.test.ts`: capacitor/inductor 파서 성공 케이스로 갱신
- `tests/engine/integration/dcAnalysisPipeline.test.ts`: parser에서 이제 지원되는 capacitor 대신 diode를 미지원 타입 샘플로 사용

### 제거된 기능

- 없음

## 🧪 테스트

```bash
npm run test -- tests/engine/components/capacitor.test.ts
# Test Files 1 passed (1), Tests 19 passed (19)

npm run test -- tests/engine/components/inductor.test.ts
# Test Files 1 passed (1), Tests 19 passed (19)

npm run type-check
# tsc --noEmit 통과

npm run lint
# eslint 통과

npm run format:check
# All matched files use Prettier code style!

npm run test
# Test Files 29 passed | 1 skipped (30), Tests 782 passed | 11 skipped (793)
```

**테스트 결과:**

- [x] 기존 테스트 모두 통과
- [x] 새로운 테스트 추가
- [ ] CI 파이프라인 통과

## 📸 스크린샷 (UI 변경 시)

UI 변경 없음

## ⚡ 성능 영향

- [x] 성능에 영향 없음
- [ ] 성능 개선
- [ ] 성능 영향 있음 (아래 설명 필수)

## 📚 문서

- [ ] 문서 업데이트 완료 (필요시)
- [x] JSDoc/주석 작성

## ✅ 코드 품질

- [x] JSDoc/주석이 현재 구현과 일치함
- [x] 새로운 에러 코드가 ADR-002 설계 원칙을 따름 (새 에러 코드 추가 없음)

## 🚨 Breaking Changes

- [x] 없음
- [ ] 있음 (아래 설명 필수)

## Codex 확인

- Deviation from brief: 없음. 단, parser 지원 추가로 기존 테스트의 낡은 “capacitor/inductor 미지원” 기대를 갱신했고, 통합 테스트의 미지원 타입 샘플을 `diode`로 교체했습니다.
- Forbidden files untouched: `src/engine/solver/mnaAssembler.ts`, `src/types/component.ts`, `src/types/circuit.ts` 모두 미수정 확인.